### PR TITLE
Alternative implementation of desktop shortcuts removing and fix for `setup.exe`

### DIFF
--- a/Batch/Both.bat
+++ b/Batch/Both.bat
@@ -61,16 +61,36 @@ for /f "delims=" %%d in ('dir /ad /b /s "%ProgramFiles(x86)%\Microsoft\EdgeWebVi
 
 
 
-:# Additional Files
+REM #Additional Files
+
+REM Desktop icon
+:users_cleanup
 echo - Removing Additional Files
 
-:: %ProfilesDir% = %SystemDrive%\Users
-for /f "tokens=3 delims=	 " %%A in ('reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList" /v ProfilesDirectory ^| findstr ProfilesDirectory') do set ProfilesDir=%%A
+set "REG_USERS_PATH=HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList"
+for /f "skip=2 tokens=2*" %%c in ('reg query "%REG_USERS_PATH%" /v Public') do ( call :user_rem_lnks_by_path %%d )
+for /f "skip=2 tokens=2*" %%c in ('reg query "%REG_USERS_PATH%" /v Default') do ( call :user_rem_lnks_by_path %%d )
+for /f "skip=1 tokens=7 delims=\" %%k in ('reg query "%REG_USERS_PATH%" /k /f "*"') do ( call :user_rem_lnks_by_sid %%k )
+goto users_done
 
-:: Desktop icon
-for /f "delims=" %%a in ('dir /b "%ProfilesDir%"') do (
-del /S /Q "%ProfilesDir%\%%a\Desktop\edge.lnk" >nul 2>&1
-del /S /Q "%ProfilesDir%\%%a\Desktop\Microsoft Edge.lnk" >nul 2>&1)
+:user_rem_lnks_by_sid
+if "%1"=="S-1-5-18" goto user_end
+if "%1"=="S-1-5-19" goto user_end
+if "%1"=="S-1-5-20" goto user_end
+for /f "skip=2 tokens=2*" %%c in ('reg query "%REG_USERS_PATH%\%1" /v ProfileImagePath') do (
+	call :user_rem_lnks_by_path %%d
+	if "%UserProfile%"=="%%d" set "USER_SID=%1"
+)
+goto user_end
+
+:user_rem_lnks_by_path
+del /s /q "%1\Desktop\edge.lnk" >nul 2>&1
+del /s /q "%1\Desktop\Microsoft Edge.lnk" >nul 2>&1
+
+:user_end
+exit /b 0
+
+:users_done
 
 :: System32
 if exist "%SystemRoot%\System32\MicrosoftEdgeCP.exe" (
@@ -113,12 +133,17 @@ for %%n in (%service_names%) do (
 
 :# APPX
 echo - Removing APPX
+
+if defined USER_SID goto rem_appX
 for /f "delims=" %%a in ('powershell "(New-Object System.Security.Principal.NTAccount($env:USERNAME)).Translate([System.Security.Principal.SecurityIdentifier]).Value"') do set "USER_SID=%%a"
+
+:rem_appX
+set "REG_APPX_STORE=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore"
 for /f "delims=" %%a in ('powershell -NoProfile -Command "Get-AppxPackage -AllUsers | Where-Object { $_.PackageFullName -like '*microsoftedge*' } | Select-Object -ExpandProperty PackageFullName"') do ( 
     if not "%%a"=="" ( 
-        reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\EndOfLife\%USER_SID%\%%a" /f >nul 2>&1
-        reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\EndOfLife\S-1-5-18\%%a" /f >nul 2>&1
-        reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Deprovisioned\%%a" /f >nul 2>&1
+        reg add "%REG_APPX_STORE%\EndOfLife\%USER_SID%\%%a" /f >nul 2>&1
+        reg add "%REG_APPX_STORE%\EndOfLife\S-1-5-18\%%a" /f >nul 2>&1
+        reg add "%REG_APPX_STORE%\Deprovisioned\%%a" /f >nul 2>&1
         powershell -Command "Remove-AppxPackage -Package '%%a'" 2>nul
         powershell -Command "Remove-AppxPackage -Package '%%a' -AllUsers" 2>nul
     )

--- a/Batch/Both.bat
+++ b/Batch/Both.bat
@@ -45,18 +45,21 @@ if exist "%tmp%\setup.exe" (
 
 echo.
 
-:# Edge
+REM #Edge
 echo - Removing Edge
-if exist "%ProgramFiles(x86)%\Microsoft\Edge\Application\" (
-for /f "delims=" %%a in ('dir /b "%ProgramFiles(x86)%\Microsoft\Edge\Application\"') do (
-start /w "" "%SRC%" --uninstall --system-level --force-uninstall))
+where /q "%ProgramFiles(x86)%\Microsoft\Edge\Application:*"
+if %errorlevel% neq 0 goto uninst_wv
+start /w "" "%SRC%" --uninstall --system-level --force-uninstall
 
-:# WebView
+REM #WebView
+:uninst_wv
 echo - Removing WebView
-if exist "%ProgramFiles(x86)%\Microsoft\EdgeWebView\Application\" (
-for /f "delims=" %%a in ('dir /b "%ProgramFiles(x86)%\Microsoft\EdgeWebView\Application\"') do (
-start /w "" "%SRC%" --uninstall --msedgewebview --system-level --force-uninstall))
-::Delete empty folders
+where /q "%ProgramFiles(x86)%\Microsoft\EdgeWebView\Application:*"
+if %errorlevel% neq 0 goto cleanup_wv_junk
+start /w "" "%SRC%" --uninstall --msedgewebview --system-level --force-uninstall
+REM Delete empty folders
+:cleanup_wv_junk
+REM rd /s /q "%ProgramFiles(x86)%\Microsoft\EdgeWebView" >NUL 2>&1
 for /f "delims=" %%d in ('dir /ad /b /s "%ProgramFiles(x86)%\Microsoft\EdgeWebView" 2^>nul ^| sort /r') do rd "%%d" 2>nul
 
 

--- a/Batch/Edge-Appx.bat
+++ b/Batch/Edge-Appx.bat
@@ -9,11 +9,13 @@ title Edge Remover - 2/18/2025
 echo - Removing APPX
 
 for /f "delims=" %%a in ('powershell "(New-Object System.Security.Principal.NTAccount($env:USERNAME)).Translate([System.Security.Principal.SecurityIdentifier]).Value"') do set "USER_SID=%%a"
+
+set "REG_APPX_STORE=HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore"
 for /f "delims=" %%a in ('powershell -NoProfile -Command "Get-AppxPackage -AllUsers | Where-Object { $_.PackageFullName -like '*microsoftedge*' } | Select-Object -ExpandProperty PackageFullName"') do ( 
     if not "%%a"=="" ( 
-        reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\EndOfLife\%USER_SID%\%%a" /f >nul 2>&1
-        reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\EndOfLife\S-1-5-18\%%a" /f >nul 2>&1
-        reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Deprovisioned\%%a" /f >nul 2>&1
+        reg add "%REG_APPX_STORE%\EndOfLife\%USER_SID%\%%a" /f >nul 2>&1
+        reg add "%REG_APPX_STORE%\EndOfLife\S-1-5-18\%%a" /f >nul 2>&1
+        reg add "%REG_APPX_STORE%\Deprovisioned\%%a" /f >nul 2>&1
         powershell -Command "Remove-AppxPackage -Package '%%a'" 2>nul
         powershell -Command "Remove-AppxPackage -Package '%%a' -AllUsers" 2>nul
     )

--- a/Batch/Edge.bat
+++ b/Batch/Edge.bat
@@ -45,11 +45,11 @@ if exist "%tmp%\setup.exe" (
 
 echo.
 
-:# Edge
+REM #Edge
 echo - Removing Edge
-if exist "%ProgramFiles(x86)%\Microsoft\Edge\Application\" (
-for /f "delims=" %%a in ('dir /b "%ProgramFiles(x86)%\Microsoft\Edge\Application\"') do (
-start /w "" "%SRC%" --uninstall --system-level --force-uninstall))
+where /q "%ProgramFiles(x86)%\Microsoft\Edge\Application:*"
+if %errorlevel% neq 0 goto uninst_wv
+start /w "" "%SRC%" --uninstall --system-level --force-uninstall
 
 
 


### PR DESCRIPTION
first of all - final scripts not tested as a solid units, only changed parts as separate scripts in echo mode at non-target OS (reason why i can't test them completely)

what changed:

\- as was hinted in issue - registry is good cuz allow get exact path for each profile without any guessing. i mean that while system variable may be unchanged, certain profiles can be altered.
so in alternative implementation script walk through every profile key in registry, grab its path and do his things.

<br/>

\- second is issue that should exists - i did not reproduce it directly, but with echo and the following line of code ([from here](https://github.com/ShadowWhisperer/Remove-MS-Edge/blob/e6e2dc724ec1b9cbcbf85d8d70cbe9d40184b93d/Batch/Both.bat#L54-L55))
```bat
for /f "delims=" %%a in ('dir /b "C:\Windows"') do ( echo %%a )
```
here path changed to another and `start setup.exe` to simple `echo` - result is pretty unwilling
so here is a fix for this - `where` in quiet mode that simply (re)set `%errorLevel%`
additionally fix contains comment with possible alternative way to simply delete entire WebView directory