### PR TITLE
Fix: Edge-only removal deletes WebView2's shared EdgeCore engine files

### DIFF
--- a/Batch/Edge.bat
+++ b/Batch/Edge.bat
@@ -238,7 +238,7 @@ echo [cleanup().edge] %bat_dbg%
 REM Delete Edge empty folders
 echo [cleanup().edge.dirs] %bat_dbg%
 rd /s /q "%x86ProgramsFolder%\Microsoft\Edge" %bat_log%
-rd /s /q "%x86ProgramsFolder%\Microsoft\EdgeCore" %bat_log%
+call :edgecore_cleanup %bat_log%
 rd /s /q "%x86ProgramsFolder%\Microsoft\EdgeUpdate" %bat_log%
 rd /s /q "%x86ProgramsFolder%\Microsoft\Temp" %bat_log%
 rd /s /q "%AllUsersProfile%\Microsoft\EdgeUpdate" %bat_log%
@@ -539,6 +539,37 @@ echo service removed %cll_dbg%
 
 :_service_remove.end
 echo [service_remove().end] %cll_dbg%
+exit /b 0
+
+
+REM EdgeCore holds the actual Edge/WebView2 engine binaries: each installed
+REM version (Edge browser and/or WebView2 Runtime) gets its own subfolder there.
+REM This script does not touch WebView2, but a blanket "rd /s /q" on EdgeCore
+REM deletes WebView2's active engine files too, breaking it (and anything
+REM depending on it, e.g. Windows Search, many Electron/embedded-browser apps).
+REM Only delete subfolders that do not match the currently registered WebView2
+REM Runtime version.
+:edgecore_cleanup
+echo [edgecore_cleanup()] %cll_dbg%
+if not exist "%x86ProgramsFolder%\Microsoft\EdgeCore" goto _edgecore_cleanup.end
+
+set "webview2_ver="
+for /f "tokens=2,*" %%a in ('reg query "HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" /v pv 2^>NUL ^| findstr /i "REG_SZ"') do set "webview2_ver=%%b"
+echo webview2_ver: "%webview2_ver%" %cll_dbg%
+
+for /d %%d in ("%x86ProgramsFolder%\Microsoft\EdgeCore\*") do (
+	if /i not "%%~nxd" equ "%webview2_ver%" (
+		echo removing: "%%~d" %cll_dbg%
+		rd /s /q "%%~d"
+	) else (
+		echo keeping ^(in use by WebView2^): "%%~d" %cll_dbg%
+	)
+)
+REM remove the now-empty parent folder; fails silently (as intended) if WebView2's subfolder is still there
+rd "%x86ProgramsFolder%\Microsoft\EdgeCore" 2>NUL
+
+:_edgecore_cleanup.end
+echo [edgecore_cleanup().end] %cll_dbg%
 exit /b 0
 
 


### PR DESCRIPTION
`Batch/Edge.bat`'s cleanup step does `rd /s /q` on the entire `EdgeCore` folder, but `EdgeCore` isn't Edge-exclusive - it's shared storage where both the Edge browser and WebView2 Runtime keep their actual engine binaries, one subfolder per version. In Edge-only mode this deletes WebView2's active engine files too, breaking WebView2 for anything depending on it (Windows Search, many Electron/embedded-browser apps) even though the script never touches `EdgeWebView` itself.

Reproduced on a real machine: WebView2 stayed registered/"installed" per Windows but its engine folder was gone, since deletion only failed for other files by coincidence (in-use locks at that moment) - an idle system would've silently lost WebView2 entirely.

Fix: only delete `EdgeCore` subfolders that don't match the version currently registered for WebView2 Runtime (read from `HKLM\...\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}`), then remove the now-empty parent folder. `Both.bat` is untouched - it intentionally removes WebView2 too, so its blanket deletion there is correct.

**Known limitation observed during testing, unrelated to this fix**: two files inside the *orphaned* (non-WebView2) `EdgeCore` version subfolder - `libEGL.dll` and `libGLESv2.dll` (ANGLE graphics libraries) - consistently resisted deletion even after `takeown`/`icacls` granting full control, with no process holding them open (confirmed via module scan) and no change across a full reboot. ~25MB of inert leftover in an otherwise-orphaned folder. Didn't block writing this fix, but flagging in case anyone recognizes the cause (possibly a GPU driver-level handle on ANGLE binaries) - could be a useful lead for further hardening the cleanup logic.